### PR TITLE
fix:  end event propagation issue

### DIFF
--- a/index.js
+++ b/index.js
@@ -151,7 +151,14 @@ function retryRequest(requestOpts, opts, callback) {
           streamResponseHandled = true;
           onResponse(null, resp, body);
         })
-        .on('complete', retryStream.emit.bind(retryStream, 'complete'));
+        .on('complete', retryStream.emit.bind(retryStream, 'complete'))
+        .on('end', function () {
+          if (streamMode) {
+            retryStream.emit('end');
+          } else {
+            callback();
+          }
+        });
 
       requestStream.pipe(delayStream);
     } else {

--- a/test.js
+++ b/test.js
@@ -185,6 +185,21 @@ describe('retry-request', function () {
           done();
         });
     });
+
+    it('emits an `end` event', function (done) {
+      var opts = {
+        request: function () {
+          var fakeRequestStream = through();
+          setImmediate(function () {
+            fakeRequestStream.emit('end');
+          })
+          return fakeRequestStream;
+        }
+      };
+      retryRequest(URI_200, opts)
+        .on('request', function () { })
+        .on('end', done);
+    });
   });
 
   describe('callbacks', function () {


### PR DESCRIPTION
Handle `end` event that is not being emitted.